### PR TITLE
Implement Statistics for New Cards Learned per Day

### DIFF
--- a/app/src/main/java/org/liberty/android/fantastischmemo/AnyMemoDBOpenHelper.java
+++ b/app/src/main/java/org/liberty/android/fantastischmemo/AnyMemoDBOpenHelper.java
@@ -33,7 +33,7 @@ public class AnyMemoDBOpenHelper extends OrmLiteSqliteOpenHelper {
 
     private final String dbPath;
 
-    private static final int CURRENT_VERSION = 4;
+    private static final int CURRENT_VERSION = 5;
 
     private CardDao cardDao = null;
 
@@ -157,6 +157,10 @@ public class AnyMemoDBOpenHelper extends OrmLiteSqliteOpenHelper {
             database.execSQL("update settings set answerTextColor = ? where answerTextColor = ?", new Object[] {null, 0xFFBEBEBE} );
             database.execSQL("update settings set questionBackgroundColor = ? where questionBackgroundColor = ?", new Object[] {null, 0xFF000000});
             database.execSQL("update settings set answerBackgroundColor = ? where answerBackgroundColor = ?", new Object[] {null, 0xFF000000});
+        }
+        if (oldVersion <= 4) {
+            database.execSQL("alter table learning_data add column firstLearnDate VARCHAR");
+            database.execSQL("update learning_data set firstLearnDate='2010-01-01 00:00:00.000000'");
         }
     }
 

--- a/app/src/main/java/org/liberty/android/fantastischmemo/dao/CardDao.java
+++ b/app/src/main/java/org/liberty/android/fantastischmemo/dao/CardDao.java
@@ -56,6 +56,9 @@ public interface CardDao extends HelperDao<Card, Integer> {
     /* get the number cards that scheduled between startDate and endDate */
     long getScheduledCardCount(Category filterCategory, Date startDate, Date endDate);
 
+    /* get the number cards which was newly learned between startDate and endDate */
+    long getNewLearnedCardCount(Category filterCategory, Date startDate, Date endDate);
+
     /* Number of cards that was graded with "grade" */
     long getNumberOfCardsWithGrade(int grade);
 

--- a/app/src/main/java/org/liberty/android/fantastischmemo/dao/CardDaoImpl.java
+++ b/app/src/main/java/org/liberty/android/fantastischmemo/dao/CardDaoImpl.java
@@ -340,7 +340,6 @@ public class CardDaoImpl extends AbstractHelperDaoImpl<Card, Integer> implements
             }
             return cs;
         } catch (SQLException e) {
-            e.printStackTrace();
             throw new RuntimeException(e);
         }
     }

--- a/app/src/main/java/org/liberty/android/fantastischmemo/dao/CardDaoImpl.java
+++ b/app/src/main/java/org/liberty/android/fantastischmemo/dao/CardDaoImpl.java
@@ -431,6 +431,32 @@ public class CardDaoImpl extends AbstractHelperDaoImpl<Card, Integer> implements
         }
     }
 
+    public long getNewLearnedCardCount(Category filterCategory, Date startDate, Date endDate) {
+        try {
+            LearningDataDao learningDataDao = getHelper().getLearningDataDao();
+            QueryBuilder<Card, Integer> cardQb = queryBuilder();
+            QueryBuilder<LearningData, Integer> learnQb = learningDataDao.queryBuilder();
+            cardQb.setCountOf(true);
+            cardQb.selectColumns("id");
+            learnQb.selectColumns("id");
+
+            learnQb.where().le("firstLearnDate", endDate)
+                    .and().ge("firstLearnDate", startDate)
+                    .and().gt("acqReps", "0").prepare();
+
+            Where<Card, Integer> where = cardQb.where().in("learningData_id", learnQb);
+            if (filterCategory != null) {
+                where.and().eq("category_id", filterCategory.getId());
+            }
+            cardQb.setWhere(where);
+
+            return countOf(cardQb.prepare());
+        } catch (SQLException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+    }
+
     public long getNumberOfCardsWithGrade(int grade) {
         try {
             LearningDataDao learningDataDao = getHelper().getLearningDataDao();

--- a/app/src/main/java/org/liberty/android/fantastischmemo/dao/LearningDataDaoImpl.java
+++ b/app/src/main/java/org/liberty/android/fantastischmemo/dao/LearningDataDaoImpl.java
@@ -57,6 +57,7 @@ public class LearningDataDaoImpl extends AbstractHelperDaoImpl<LearningData, Int
     public void markAsLearnedForever(LearningData ld) {
         // 2099-12-31
         ld.setNextLearnDate(new Date(4102358400000L));
+        ld.setFirstLearnDate(new Date());
         ld.setAcqReps(1);
         ld.setGrade(5);
         update(ld);

--- a/app/src/main/java/org/liberty/android/fantastischmemo/entity/LearningData.java
+++ b/app/src/main/java/org/liberty/android/fantastischmemo/entity/LearningData.java
@@ -44,6 +44,9 @@ public class LearningData {
     @DatabaseField(format="yyyy-MM-dd HH:mm:ss.SSSSSS", dataType=DataType.DATE_STRING)
     private Date updateDate;
 
+    @DatabaseField(defaultValue = "2010-01-01 00:00:00.000000", format="yyyy-MM-dd HH:mm:ss.SSSSSS", dataType=DataType.DATE_STRING)
+    private Date firstLearnDate = new Date(1262304000000L);
+
     public LearningData() {}
 
 	public Integer getId() {
@@ -134,6 +137,14 @@ public class LearningData {
 		this.updateDate = updateDate;
 	}
 
+	public Date getFirstLearnDate() {
+		return firstLearnDate;
+	}
+
+	public void setFirstLearnDate(Date firstLearnDate) {
+		this.firstLearnDate = firstLearnDate;
+	}
+
     public void cloneFromLearningData(LearningData ld) {
         setAcqReps(ld.getAcqReps());
         setAcqRepsSinceLapse(ld.getAcqRepsSinceLapse());
@@ -144,6 +155,7 @@ public class LearningData {
         setNextLearnDate(ld.getNextLearnDate());
         setRetReps(ld.getRetReps());
         setRetRepsSinceLapse(ld.getRetRepsSinceLapse());
+        setFirstLearnDate(ld.getFirstLearnDate());
     }
 
     public double getInterval() {
@@ -158,6 +170,6 @@ public class LearningData {
 				+ ", retReps=" + retReps + ", lapses=" + lapses
 				+ ", acqRepsSinceLapse=" + acqRepsSinceLapse
 				+ ", retRepsSinceLapse=" + retRepsSinceLapse + ", updateDate="
-				+ updateDate + "]";
+				+ updateDate + ", firstLearnDate=" + firstLearnDate + "]";
 	}
 }

--- a/app/src/main/java/org/liberty/android/fantastischmemo/scheduler/DefaultScheduler.java
+++ b/app/src/main/java/org/liberty/android/fantastischmemo/scheduler/DefaultScheduler.java
@@ -62,6 +62,7 @@ public class DefaultScheduler implements Scheduler {
         int newAcqRepsSinceLapse = oldData.getAcqRepsSinceLapse();
         int newRetRepsSinceLapse = oldData.getRetRepsSinceLapse();
         float newEasiness = oldData.getEasiness();
+        Date newFirstLearnDate = oldData.getFirstLearnDate();
 
         if(actualInterval <= parameters.getMinimalInterval()){
             actualInterval = parameters.getMinimalInterval();
@@ -126,6 +127,10 @@ public class DefaultScheduler implements Scheduler {
             newInterval = newInterval + calculateIntervalNoise(newInterval);
         }
 
+        if (this.isCardNew(oldData)) {
+            newFirstLearnDate = new Date();
+        }
+
         LearningData newData = new LearningData();
         newData.setId(oldData.getId());
         newData.setAcqReps(newAcqReps);
@@ -137,6 +142,7 @@ public class DefaultScheduler implements Scheduler {
         newData.setNextLearnDate(afterDays(currentDate, newInterval));
         newData.setRetReps(newRetReps);
         newData.setRetRepsSinceLapse(newRetRepsSinceLapse);
+        newData.setFirstLearnDate(newFirstLearnDate);
         return newData;
     }
 

--- a/app/src/main/java/org/liberty/android/fantastischmemo/ui/StatisticsScreen.java
+++ b/app/src/main/java/org/liberty/android/fantastischmemo/ui/StatisticsScreen.java
@@ -174,15 +174,14 @@ public class StatisticsScreen extends AMActivity {
 
     private class NewCardTask extends ChartTask<Void, Void, BarData> {
 
-        public static final int INITIAL_CAPACITY = 30;
+        private static final int INITIAL_CAPACITY = 30;
+        private static final int MILLISECONDS_PER_DAY = 60 * 60 * 24 * 1000;
 
         @Override
         public BarData doInBackground(Void... params) {
             cardDao = dbOpenHelper.getCardDao();
-            Integer DAYS = 30;
             List<String> xVals = new ArrayList<String>(INITIAL_CAPACITY);
             List<BarEntry> yVals = new ArrayList<BarEntry>(INITIAL_CAPACITY);
-            Integer MILLISECONDS_PER_DAY = 60 * 60 * 24 * 1000;
             Date now = new Date();
             for (int i = -INITIAL_CAPACITY; i < 1; i++) {
                 Date endDate = new Date(now.getTime() + i * MILLISECONDS_PER_DAY);

--- a/app/src/main/java/org/liberty/android/fantastischmemo/ui/StatisticsScreen.java
+++ b/app/src/main/java/org/liberty/android/fantastischmemo/ui/StatisticsScreen.java
@@ -120,6 +120,10 @@ public class StatisticsScreen extends AMActivity {
                          new AccumulativeCardsToReviewTask()
                                  .execute((Void) null);
                          break;
+                     case R.id.new_cards_learned_in_the_past_month_menu:
+                         setTitle(R.string.number_of_new_cards_learned_in_a_day_text);
+                         new NewCardTask().execute((Void) null);
+                         break;
                      case R.id.grade_statistics_menu:
                          setTitle(R.string.grade_statistics_text);
                          new GradeStatisticsTask()
@@ -165,6 +169,50 @@ public class StatisticsScreen extends AMActivity {
             statisticsGraphFrame.removeAllViews();
             statisticsGraphFrame.addView(chart);
             progressDialog.dismiss();
+        }
+    }
+
+    private class NewCardTask extends ChartTask<Void, Void, BarData> {
+
+        public static final int INITIAL_CAPACITY = 30;
+
+        @Override
+        public BarData doInBackground(Void... params) {
+            cardDao = dbOpenHelper.getCardDao();
+            Integer DAYS = 30;
+            List<String> xVals = new ArrayList<String>(INITIAL_CAPACITY);
+            List<BarEntry> yVals = new ArrayList<BarEntry>(INITIAL_CAPACITY);
+            Integer MILLISECONDS_PER_DAY = 60 * 60 * 24 * 1000;
+            Date now = new Date();
+            for (int i = -INITIAL_CAPACITY; i < 1; i++) {
+                Date endDate = new Date(now.getTime() + i * MILLISECONDS_PER_DAY);
+                Date startDate = new Date(endDate.getTime() - MILLISECONDS_PER_DAY);
+                xVals.add("" + i);
+                yVals.add(new BarEntry((float)cardDao.getNewLearnedCardCount(null, startDate, endDate),
+                                       INITIAL_CAPACITY + i)); // the order has to be nonnegative
+
+            }
+
+            BarDataSet dataSet = new BarDataSet(yVals, getString(R.string.number_of_new_cards_learned_in_a_day_text));
+            BarData data = new BarData(xVals, dataSet);
+            data.setValueTextColor(Color.WHITE);
+
+            return data;
+
+        }
+
+        @Override
+        public Chart generateChart(BarData data) {
+            BarChart chart = new BarChart(StatisticsScreen.this);
+            chart.setDrawGridBackground(false);
+            chart.getLegend().setTextColor(Color.WHITE);
+            chart.getXAxis().setTextColor(Color.WHITE);
+            chart.getAxisLeft().setTextColor(Color.WHITE);
+            chart.getAxisRight().setTextColor(Color.WHITE);
+
+            chart.setData(data);
+            chart.setDescription("");
+            return chart;
         }
     }
 

--- a/app/src/main/res/menu/statistics_screen_menu.xml
+++ b/app/src/main/res/menu/statistics_screen_menu.xml
@@ -9,6 +9,9 @@
             android:id="@+id/accumulative_cards_scheduled_menu"
             android:title="@string/accumulative_cards_scheduled_text"/>
         <item
+            android:id="@+id/new_cards_learned_in_the_past_month_menu"
+            android:title="@string/number_of_new_cards_learned_in_a_day_text"/>
+        <item
             android:id="@+id/grade_statistics_menu"
             android:title="@string/grade_statistics_text"/>
     </group>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -446,4 +446,5 @@
     <string name="greek_text">Griechisch</string>
     <string name="hour_text">h</string>
     <string name="minute_text">min</string>
+    <string name="number_of_new_cards_learned_in_a_day_text">Anzahl der neu erlernten Karteikarten / Tag</string> 
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -436,4 +436,5 @@
     <string name="download_source_cram">Cram</string>
     <string name="load_more_text">载入更多</string>
     <string name="search_by_title_text">按标题搜索</string>
+    <string name="number_of_new_cards_learned_in_a_day_text">每天新词数</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -436,4 +436,5 @@
     <string name="download_source_cram">Cram</string>
     <string name="load_more_text">載入更多</string>
     <string name="search_by_title_text">按標題搜索</string>
+    <string name="number_of_new_cards_learned_in_a_day_text">每天新詞數</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -332,6 +332,7 @@
     <string name="statistics_type_text">Statistics type</string>
     <string name="cards_to_review_text">Cards scheduled in a month</string>
     <string name="number_of_cards_scheduled_in_a_day_text">Number of cards scheduled in a day</string>
+        <string name="number_of_new_cards_learned_in_a_day_text">Number of new cards learned in a day</string>
     <string name="grade_statistics_text">Grade statistics</string>
     <string name="accumulative_cards_scheduled_text">Accumulative cards scheduled</string>
     <string name="google_drive_spreadsheet_text">Google Drive spreadsheet</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -332,7 +332,7 @@
     <string name="statistics_type_text">Statistics type</string>
     <string name="cards_to_review_text">Cards scheduled in a month</string>
     <string name="number_of_cards_scheduled_in_a_day_text">Number of cards scheduled in a day</string>
-        <string name="number_of_new_cards_learned_in_a_day_text">Number of new cards learned in a day</string>
+    <string name="number_of_new_cards_learned_in_a_day_text">Number of new cards learned in a day</string>
     <string name="grade_statistics_text">Grade statistics</string>
     <string name="accumulative_cards_scheduled_text">Accumulative cards scheduled</string>
     <string name="google_drive_spreadsheet_text">Google Drive spreadsheet</string>


### PR DESCRIPTION
Implemented the statistics function for new cards learned per day:

   * Additional menu in the Statistics UI
   * Additional column `firstLearnDate` in the learning_data table
   * Backward compatible handling for the `firstLearnDate` in scheduler
     (all the old cards would have a default `firstLeanDate` at 2010)