### PR TITLE
Error handling for failed listFiles()

### DIFF
--- a/app/src/main/java/org/liberty/android/fantastischmemo/ui/FileBrowserFragment.java
+++ b/app/src/main/java/org/liberty/android/fantastischmemo/ui/FileBrowserFragment.java
@@ -38,6 +38,8 @@ import android.view.ViewGroup;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
+
 import com.google.common.base.Strings;
 import org.apache.commons.io.FileUtils;
 import org.liberty.android.fantastischmemo.AMActivity;
@@ -193,9 +195,16 @@ public class FileBrowserFragment extends RoboDialogFragment {
 
     private void browseTo(final File aDirectory){
         if(aDirectory.isDirectory()){
-            titleTextView.setText(aDirectory.getPath());
-            this.currentDirectory = aDirectory;
-            fill(aDirectory.listFiles());
+            File[] listedFiles = aDirectory.listFiles();
+            if (listedFiles != null) {
+                titleTextView.setText(aDirectory.getPath());
+                this.currentDirectory = aDirectory;
+                fill(listedFiles);
+            } else {
+                Toast.makeText(filesListRecyclerView.getContext(),
+                               R.string.change_directory_permission_denied_message,
+                               Toast.LENGTH_SHORT).show();
+            }
         }
     }
 
@@ -493,7 +502,7 @@ public class FileBrowserFragment extends RoboDialogFragment {
                     if(selectedFileName.equals(CURRENT_DIR)){
                         /* Do nothing */
                     } else if(selectedFileName.equals(UP_ONE_LEVEL_DIR)){
-                        /* Do nithing */
+                        /* Do nothing */
                     } else {
                         final File clickedFile;
                         switch(fragment.displayMode){

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -447,4 +447,5 @@
     <string name="hour_text">h</string>
     <string name="minute_text">min</string>
     <string name="number_of_new_cards_learned_in_a_day_text">Anzahl der neu erlernten Karteikarten / Tag</string> 
+    <string name="change_directory_permission_denied_message">AnyMemo hat kein Zugriffsrecht auf den Ordner.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -437,4 +437,5 @@
     <string name="load_more_text">载入更多</string>
     <string name="search_by_title_text">按标题搜索</string>
     <string name="number_of_new_cards_learned_in_a_day_text">每天新词数</string>
+    <string name="change_directory_permission_denied_message">AnyMemo没有读取该文件夹的权限。</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -437,4 +437,5 @@
     <string name="load_more_text">載入更多</string>
     <string name="search_by_title_text">按標題搜索</string>
     <string name="number_of_new_cards_learned_in_a_day_text">每天新詞數</string>
+    <string name="change_directory_permission_denied_message">AnyMemo沒有讀取該資料夾的權限。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -458,4 +458,5 @@
     <string name="write_storage_permission_denied_message">AnyMemo could not get permission to write db file on external storage.</string>
     <string name="db_file_is_corrupted_text">DB file is corrupted</string>
     <string name="clear_text">Clear</string>
+    <string name="change_directory_permission_denied_message">AnyMemo could not get permission to change to the directory.</string>
 </resources>


### PR DESCRIPTION
The file browser could cause exception when the listFiles() methods
failed and returned a null pointer. Now it is properly handled and
the app would not crash in this case.