### PR TITLE
File browser fixes

### DIFF
--- a/app/src/main/java/org/liberty/android/fantastischmemo/ui/FileBrowserFragment.java
+++ b/app/src/main/java/org/liberty/android/fantastischmemo/ui/FileBrowserFragment.java
@@ -38,6 +38,8 @@ import android.view.ViewGroup;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
+
 import com.google.common.base.Strings;
 import org.apache.commons.io.FileUtils;
 import org.liberty.android.fantastischmemo.AMActivity;
@@ -193,9 +195,16 @@ public class FileBrowserFragment extends RoboDialogFragment {
 
     private void browseTo(final File aDirectory){
         if(aDirectory.isDirectory()){
-            titleTextView.setText(aDirectory.getPath());
-            this.currentDirectory = aDirectory;
-            fill(aDirectory.listFiles());
+            File[] listedFiles = aDirectory.listFiles();
+            if (listedFiles != null) {
+                titleTextView.setText(aDirectory.getPath());
+                this.currentDirectory = aDirectory;
+                fill(listedFiles);
+            } else {
+                Toast.makeText(filesListRecyclerView.getContext(),
+                               R.string.change_directory_permission_denied_message,
+                               Toast.LENGTH_SHORT).show();
+            }
         }
     }
 
@@ -493,7 +502,7 @@ public class FileBrowserFragment extends RoboDialogFragment {
                     if(selectedFileName.equals(CURRENT_DIR)){
                         /* Do nothing */
                     } else if(selectedFileName.equals(UP_ONE_LEVEL_DIR)){
-                        /* Do nithing */
+                        /* Do nothing */
                     } else {
                         final File clickedFile;
                         switch(fragment.displayMode){

--- a/app/src/main/java/org/liberty/android/fantastischmemo/ui/FileBrowserFragment.java
+++ b/app/src/main/java/org/liberty/android/fantastischmemo/ui/FileBrowserFragment.java
@@ -75,6 +75,7 @@ public class FileBrowserFragment extends RoboDialogFragment {
     private RecyclerView filesListRecyclerView;
     private FileBrowserAdapter fileListAdapter;
     private FloatingActionButton addDbButton;
+    private TextView filesListEmptyView;
 
     private TextView titleTextView;
     private boolean dismissOnSelect = false;
@@ -169,6 +170,9 @@ public class FileBrowserFragment extends RoboDialogFragment {
         filesListRecyclerView.setLayoutManager(new LinearLayoutManager(filesListRecyclerView.getContext()));
         titleTextView = (TextView) v.findViewById(R.id.file_path_title);
 
+        filesListEmptyView = (TextView) v.findViewById(R.id.empty_text_view);
+        filesListEmptyView.setText(R.string.directory_empty_text);
+
         fileListAdapter = new FileBrowserAdapter(this);
         filesListRecyclerView.setAdapter(fileListAdapter);
 
@@ -235,6 +239,12 @@ public class FileBrowserFragment extends RoboDialogFragment {
                 }
 
             }
+        }
+
+        if (files.length > 0) {
+            this.filesListEmptyView.setVisibility(View.INVISIBLE);
+        } else {
+            this.filesListEmptyView.setVisibility(View.VISIBLE);
         }
 
         this.fileListAdapter.setItems(directoryEntries);

--- a/app/src/main/res/layout/file_browser.xml
+++ b/app/src/main/res/layout/file_browser.xml
@@ -7,18 +7,36 @@
     android:layout_height="match_parent"
     android:fitsSystemWindows="true">
 
-    <TextView android:id="@+id/file_path_title"
-        android:textSize="14dp"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
-
-    <android.support.v7.widget.RecyclerView
-        android:id="@+id/file_list"
-        android:scrollbars="vertical"
-        android:fadeScrollbars="true"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+        android:layout_gravity="center_horizontal"
+        android:orientation="vertical">
+
+        <TextView android:id="@+id/file_path_title"
+            android:textSize="14dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <android.support.v7.widget.RecyclerView
+            android:id="@+id/file_list"
+            android:scrollbars="vertical"
+            android:fadeScrollbars="true"
+            android:layout_below="@+id/file_path_title"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:fillViewport="true"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+        <TextView
+            android:id="@+id/empty_text_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/margin"
+            android:gravity="center"
+            android:textSize="20dp"
+            android:visibility="gone" />
+    </LinearLayout>
 
     <android.support.design.widget.FloatingActionButton
         android:id="@+id/add_db_fab"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -448,4 +448,5 @@
     <string name="minute_text">min</string>
     <string name="number_of_new_cards_learned_in_a_day_text">Anzahl der neu erlernten Karteikarten / Tag</string> 
     <string name="change_directory_permission_denied_message">AnyMemo hat kein Zugriffsrecht auf den Ordner.</string>
+    <string name="directory_empty_text">(Leeres Verzeichnis)</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -447,4 +447,5 @@
     <string name="hour_text">h</string>
     <string name="minute_text">min</string>
     <string name="number_of_new_cards_learned_in_a_day_text">Anzahl der neu erlernten Karteikarten / Tag</string> 
+    <string name="change_directory_permission_denied_message">AnyMemo hat kein Zugriffsrecht auf den Ordner.</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -253,4 +253,5 @@
     <string name="fe_logout_text">ログアウト</string>
     <string name="linebreak_conversion">改行をHTML形式に自動変換</string>
     <string name="locale_japanese_text">日本語</string>
+    <string name="directory_empty_text">（空ディレクトリ）</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -437,4 +437,5 @@
     <string name="load_more_text">载入更多</string>
     <string name="search_by_title_text">按标题搜索</string>
     <string name="number_of_new_cards_learned_in_a_day_text">每天新词数</string>
+    <string name="change_directory_permission_denied_message">AnyMemo没有读取该文件夹的权限。</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -438,4 +438,5 @@
     <string name="search_by_title_text">按标题搜索</string>
     <string name="number_of_new_cards_learned_in_a_day_text">每天新词数</string>
     <string name="change_directory_permission_denied_message">AnyMemo没有读取该文件夹的权限。</string>
+    <string name="directory_empty_text">（文件夹为空）</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -437,4 +437,5 @@
     <string name="load_more_text">載入更多</string>
     <string name="search_by_title_text">按標題搜索</string>
     <string name="number_of_new_cards_learned_in_a_day_text">每天新詞數</string>
+    <string name="change_directory_permission_denied_message">AnyMemo沒有讀取該資料夾的權限。</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -438,4 +438,5 @@
     <string name="search_by_title_text">按標題搜索</string>
     <string name="number_of_new_cards_learned_in_a_day_text">每天新詞數</string>
     <string name="change_directory_permission_denied_message">AnyMemo沒有讀取該資料夾的權限。</string>
+    <string name="directory_empty_text">（資料夾為空）</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -459,4 +459,5 @@
     <string name="db_file_is_corrupted_text">DB file is corrupted</string>
     <string name="clear_text">Clear</string>
     <string name="change_directory_permission_denied_message">AnyMemo could not get permission to change to the directory.</string>
+    <string name="directory_empty_text">(Empty directory)</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -458,4 +458,5 @@
     <string name="write_storage_permission_denied_message">AnyMemo could not get permission to write db file on external storage.</string>
     <string name="db_file_is_corrupted_text">DB file is corrupted</string>
     <string name="clear_text">Clear</string>
+    <string name="change_directory_permission_denied_message">AnyMemo could not get permission to change to the directory.</string>
 </resources>


### PR DESCRIPTION
Three fixes for the file browser to fix bug and improve usability:    

* The file browser could cause exception when the listFiles() methods
failed and returned a null pointer. Now it is properly handled and
the app would not crash in this case.
* The title for the absolute path no longer overlaps with the first
        entry.
* String appears "(empty directory)" for the empty directy, so that
        the user wouldn't be confused, when they starts from a empty
        directory when trying to import flash cards from files.