### PR TITLE
Set note colors to answer colors

### DIFF
--- a/app/src/main/java/org/liberty/android/fantastischmemo/ui/QACardActivity.java
+++ b/app/src/main/java/org/liberty/android/fantastischmemo/ui/QACardActivity.java
@@ -305,7 +305,10 @@ public abstract class QACardActivity extends BaseActivity {
             .setTypefaceFromFile(setting.getAnswerFont())
             .setDisplayInHtml(setting.getDisplayInHTMLEnum().contains(Setting.CardField.ANSWER))
             .setHtmlLinebreakConversion(setting.getHtmlLineBreakConversion())
-            .setImageSearchPaths(imageSearchPaths);
+            .setImageSearchPaths(imageSearchPaths)
+            // TODO: separate colors for note?
+            .setTextColor(setting.getAnswerTextColor())
+            .setBackgroundColor(setting.getAnswerBackgroundColor());
 
         // Long click to launch image viewer if the card has an image
         questionFragmentBuilder.setTextOnLongClickListener(


### PR DESCRIPTION
This is not completely correct since users can display the note in
both the question and answer panels but works for users who have the
same colors for both.